### PR TITLE
Sweep: turn the install button from purple to green (✓ Sandbox Passed)

### DIFF
--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -87,4 +87,3 @@ export default function CallToAction() {
     </Container>
   );
 }
-

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -55,9 +55,9 @@ export default function CallToAction() {
         <Button
           color="white"
           p={6}
-          colorScheme={"purple"}
-          bg={"purple.400"}
-          _hover={{ bg: "purple.600" }}
+          colorScheme={"green"}
+          bg={"green.400"}
+          _hover={{ bg: "green.600" }}
           onClick={() => window.open("https://github.com/apps/sweep-ai")}
           fontSize={"xl"}
           mb="1rem !important"

--- a/src/tests/CallToAction.test.tsx
+++ b/src/tests/CallToAction.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import CallToAction from '../components/CallToAction';
+
+test('button color is green', () => {
+  const { getByText } = render(<CallToAction />);
+  const button = getByText('Install Sweep');
+  expect(button).toHaveStyle('background-color: green.400');
+});


### PR DESCRIPTION
# Description
This pull request changes the color of the install button in the CallToAction component from purple to green. It also adds a test to ensure that the button color is correctly set to green.
# Summary
- Changed the color of the install button in CallToAction component from purple to green in src/components/CallToAction.tsx.
- Added a test to check if the button color is green in src/tests/CallToAction.test.tsx.
Fixes #24.
---
### 🎉 Latest improvements to Sweep:
* We just released a [dashboard](https://progress.sweep.dev) to track Sweep's progress on your issue in real-time, showing every stage of the process – from search to planning and coding.
* Sweep uses OpenAI's latest Assistant API to **plan code changes** and **modify code**! This is 3x faster and *significantly* more reliable as it allows Sweep to edit code and validate the changes in tight iterations, the same way as a human would.
* Try using the GitHub issues extension to create Sweep issues directly from your editor! [GitHub Issues and Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github).
---
### 💡 To get Sweep to edit this pull request, you can:
* Comment below, and Sweep can edit the entire PR
* Comment on a file, Sweep will only modify the commented file
* Edit the original issue to get Sweep to recreate the PR from scratch